### PR TITLE
Simple support for PACK chunk in vox files

### DIFF
--- a/Assets/MagicaVoxel/Scripts/MVImporter.cs
+++ b/Assets/MagicaVoxel/Scripts/MVImporter.cs
@@ -350,7 +350,20 @@ public static class MVImporter
 				int readSize = 0;
 				while (readSize < childrenSize) {
 					chunkId = br.ReadBytes (4);
-					if (chunkId [0] == 'S' &&
+
+					if (chunkId [0] == 'P' &&
+						chunkId [1] == 'A' &&
+						chunkId [2] == 'C' &&
+						chunkId [3] == 'K') {
+
+						int chunkContentBytes = br.ReadInt32 ();
+						int childrenBytes = br.ReadInt32 ();
+
+						int modelCount = br.ReadInt32 ();
+
+						readSize += chunkContentBytes + childrenBytes + 4 * 3;
+					}
+					else if (chunkId [0] == 'S' &&
 						chunkId [1] == 'I' &&
 						chunkId [2] == 'Z' &&
 						chunkId [3] == 'E') {
@@ -898,7 +911,7 @@ public static class MVImporter
 								mesh.colors = colors.ToArray();
 								mesh.normals = normals.ToArray();
 								mesh.triangles = indicies.ToArray ();
-								mesh.Optimize ();
+
 								result.Add (mesh);
 
 								verts.Clear ();
@@ -921,7 +934,7 @@ public static class MVImporter
 			mesh.colors = colors.ToArray();
 			mesh.normals = normals.ToArray();
 			mesh.triangles = indicies.ToArray ();
-			mesh.Optimize ();
+
 			result.Add (mesh);
 
 			totalQuadCount += currentQuadCount;

--- a/Assets/MagicaVoxel/Shaders/VoxelAlpha.shader
+++ b/Assets/MagicaVoxel/Shaders/VoxelAlpha.shader
@@ -1,0 +1,42 @@
+Shader "MagicaVoxel/VoxelAlpha"
+{
+    Properties
+    {
+        _Color ("Main Color", Color) = (1,1,1,1)
+        _MainTex ("Color (RGB) Trans (A)", 2D) = "white" {}
+    }
+
+    SubShader
+    {
+        Tags { "Queue" = "Transparent"}
+
+        Pass
+        {
+            //ZWrite On
+            ColorMask 0
+        }
+
+        ZWrite Off // don't write to depth buffer 
+        Blend SrcAlpha OneMinusSrcAlpha // use alpha blending
+
+        CGPROGRAM
+        #pragma surface surf Lambert alpha:fade
+       
+        uniform float4 _Color;
+        uniform sampler2D _MainTex;
+
+        struct Input
+        {
+            float4 color : COLOR;
+        };
+
+        void surf (Input IN, inout SurfaceOutput o)
+        {
+            fixed4 col = IN.color * _Color;
+            o.Albedo = col.rgb;
+            o.Alpha = col.a;
+        }
+        ENDCG
+    }
+    Fallback "Glossy", 0
+}


### PR DESCRIPTION
- MagicaVoxel 0.98 files started opening after adding simple PACK chunk support.
- Remove obsolete Optimize function so that it works with Unity 2017.1
- VoxelAlpha shader which has shaded color faces and supports alpha transparency.