### PR TITLE
moved menu command into Tools/

### DIFF
--- a/Assets/MagicaVoxel/Scripts/Editor/MVEditorUtilities.cs
+++ b/Assets/MagicaVoxel/Scripts/Editor/MVEditorUtilities.cs
@@ -15,7 +15,7 @@ public static class MVEditorUtilities {
 		return AssetDatabase.LoadAssetAtPath("Assets/MagicaVoxel/Meshes/quad.asset", typeof(Mesh)) as Mesh;
 	}
 
-	[MenuItem("MagicaVoxel/Load")]
+	[MenuItem("Tools/MagicaVoxel/Load")]
 	static void Load() {
 		string path = EditorUtility.OpenFilePanel(
 			"Open VOX model",


### PR DESCRIPTION
since many plugins use the Tools/ menu for their custom commands, and this MagicaVoxel/ isn't used so much to deserve a top level menu.